### PR TITLE
'user' table migration 'bio' column definition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -140,3 +140,8 @@ All notable changes to `users` will be documented in this file
 ## 0.11.1 - 2021-04-29
 - fix issue with `UserBuilder::allWithInactive()` methods return type hinting
 - add`allWithInactive()` test method to `UserBuilderTest`
+
+
+## 0.11.2 - 2021-04-29
+- fix 'user' table migration 'bio' column definition to use `mediumText()` instead of `text()`
+- add phpunit min version

--- a/composer.json
+++ b/composer.json
@@ -28,6 +28,7 @@
         "sfneal/scopes": ">=1.0"
     },
     "require-dev": {
+        "phpunit/phpunit": ">=9.5.4",
         "orchestra/testbench": ">=6.7.1",
         "scrutinizer/ocular": "^1.8",
         "sfneal/mock-models": ">=0.5"

--- a/database/migrations/create_user_table.php.stub
+++ b/database/migrations/create_user_table.php.stub
@@ -32,7 +32,7 @@ class CreateUserTable extends Migration
             $table->string('phone_mobile')->nullable();
             $table->string('fax')->nullable();
             $table->string('website')->nullable();
-            $table->string('bio', 255)->nullable();
+            $table->mediumText('bio')->nullable();
 
             $table->string('username');
             $table->string('password');


### PR DESCRIPTION
- fix 'user' table migration 'bio' column definition to use `mediumText()` instead of `text()`
- add phpunit min version