### PR TITLE
Fix user migration's 'role_id' to be nullable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -148,4 +148,4 @@ All notable changes to `users` will be documented in this file
 
 
 ## 0.11.3 - 2021-05-03
-- fix user migration's 'role_id' to be nullable to allow use of `UserFactroy` with creating a 'role' relationship
+- fix user migration's 'role_id' column to be nullable to allow use of `UserFactory` with creating a 'role' relationship

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -145,3 +145,7 @@ All notable changes to `users` will be documented in this file
 ## 0.11.2 - 2021-04-29
 - fix 'user' table migration 'bio' column definition to use `mediumText()` instead of `text()`
 - add phpunit min version
+
+
+## 0.11.3 - 2021-05-03
+- fix user migration's 'role_id' to be nullable to allow use of `UserFactroy` with creating a 'role' relationship

--- a/database/migrations/create_user_table.php.stub
+++ b/database/migrations/create_user_table.php.stub
@@ -17,7 +17,7 @@ class CreateUserTable extends Migration
     {
         Schema::create(self::TABLE_NAME, function (Blueprint $table) {
             $table->increments('id');
-            $table->integer('role_id');
+            $table->integer('role_id')->nullable();
             $table->string('first_name');
             $table->string('middle_name')->nullable();
             $table->string('last_name');


### PR DESCRIPTION
- fix user migration's 'role_id' column to be nullable to allow use of `UserFactory` with creating a 'role' relationship