### PR TITLE
bump sfneal/laravel-helpers min version to v2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -151,5 +151,5 @@ All notable changes to `users` will be documented in this file
 - fix user migration's 'role_id' column to be nullable to allow use of `UserFactory` with creating a 'role' relationship
 
 
-## 0.11.4 - 2021-05-03
+## 0.11.4 - 2021-05-04
 - bump sfneal/laravel-helpers min version to v2.0 to enable use of `AppInfo` when installing using '--prefer-lowest' flag

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -149,3 +149,7 @@ All notable changes to `users` will be documented in this file
 
 ## 0.11.3 - 2021-05-03
 - fix user migration's 'role_id' column to be nullable to allow use of `UserFactory` with creating a 'role' relationship
+
+
+## 0.11.4 - 2021-05-03
+- bump sfneal/laravel-helpers min version to v2.0 to enable use of `AppInfo` when installing using '--prefer-lowest' flag

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -153,3 +153,5 @@ All notable changes to `users` will be documented in this file
 
 ## 0.11.4 - 2021-05-04
 - bump sfneal/laravel-helpers min version to v2.0 to enable use of `AppInfo` when installing using '--prefer-lowest' flag
+- bump sfneal/post-office min version to v0.8
+- refactor import of Sfneal\PostOffice\Notifications `AbstractNotification` to `Notification`

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "sfneal/datum": ">=1.4.1",
         "sfneal/laravel-helpers": ">=2.0",
         "sfneal/models": "^2.1",
-        "sfneal/post-office": ">=0.4.0",
+        "sfneal/post-office": ">=0.8",
         "sfneal/scopes": ">=1.0"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "sfneal/casts": ">=1.1",
         "sfneal/currency": "^2.0",
         "sfneal/datum": ">=1.4.1",
-        "sfneal/laravel-helpers": ">=1.0",
+        "sfneal/laravel-helpers": ">=2.0",
         "sfneal/models": "^2.1",
         "sfneal/post-office": ">=0.4.0",
         "sfneal/scopes": ">=1.0"

--- a/src/Queries/UserNotificationSubscriptionQuery.php
+++ b/src/Queries/UserNotificationSubscriptionQuery.php
@@ -6,7 +6,7 @@ use Illuminate\Database\Eloquent\Collection;
 use Sfneal\Caching\Traits\Cacheable;
 use Sfneal\Helpers\Laravel\AppInfo;
 use Sfneal\Helpers\Laravel\LaravelHelpers;
-use Sfneal\PostOffice\Notifications\AbstractNotification;
+use Sfneal\PostOffice\Notifications\Notification;
 use Sfneal\Queries\Query;
 use Sfneal\Users\Builders\UserBuilder;
 use Sfneal\Users\Builders\UserNotificationBuilder;
@@ -24,9 +24,9 @@ class UserNotificationSubscriptionQuery extends Query
     /**
      * UserNotificationSubscriptionQuery constructor.
      *
-     * @param AbstractNotification $notification
+     * @param Notification $notification
      */
-    public function __construct(AbstractNotification $notification)
+    public function __construct(Notification $notification)
     {
         // todo: refactor param to string?
         $this->notification = LaravelHelpers::getClassName($notification);


### PR DESCRIPTION
- bump sfneal/laravel-helpers min version to v2.0 to enable use of `AppInfo` when installing using '--prefer-lowest' flag
- bump sfneal/post-office min version to v0.8
- refactor import of Sfneal\PostOffice\Notifications `AbstractNotification` to `Notification`