### PR TITLE
Model `boot()` method declarations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -166,3 +166,7 @@ All notable changes to `users` will be documented in this file
 ## 1.0.1 - 2021-05-18
 - fix issue with `DatabaseSeeder` causing ambiguous class resolutions
 - refactor all the seeders to tests namespace except `RoleSeeder` which can be used in production
+
+
+## 1.0.2 - 2021-06-29
+- fix issue with `User` & `Role` models declarations of static `boot()` methods

--- a/src/Models/Role.php
+++ b/src/Models/Role.php
@@ -19,7 +19,7 @@ class Role extends Model
      *
      * @return void
      */
-    public static function boot()
+    protected static function boot()
     {
         parent::boot();
 

--- a/src/Models/User.php
+++ b/src/Models/User.php
@@ -31,7 +31,7 @@ class User extends AuthModel
      *
      * @return void
      */
-    public static function boot()
+    protected static function boot()
     {
         parent::boot();
 


### PR DESCRIPTION
- fix issue with `User` & `Role` models declarations of static `boot()` methods