### PR TITLE
Cut `User` model's 'password' attribute mutator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -170,3 +170,7 @@ All notable changes to `users` will be documented in this file
 
 ## 1.0.2 - 2021-06-29
 - fix issue with `User` & `Role` models declarations of static `boot()` methods
+
+
+## 1.1.0 - 2021-07-19
+- cut `User` model's 'password' attribute mutator that was causing already hashed passwords to be hashed again 

--- a/src/Models/User.php
+++ b/src/Models/User.php
@@ -291,18 +291,6 @@ class User extends AuthModel
     }
 
     /**
-     * Set the 'password' attribute.
-     *
-     * @param $value
-     */
-    public function setPasswordAttribute($value)
-    {
-        if (! empty($value)) {
-            $this->attributes['password'] = bcrypt($value);
-        }
-    }
-
-    /**
      * Mutate the 'middle_name' attribute.
      *
      * @param string|null $value


### PR DESCRIPTION
- cut `User` model's 'password' attribute mutator that was causing already hashed passwords to be hashed again