### PR TITLE
sfneal/mock-models v0.9 upgrade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -183,3 +183,8 @@ All notable changes to `users` will be documented in this file
 
 ## 1.1.2 - 2021-08-03
 - fix min sfneal/address version to v1.2.2 to fix issues with previously fixed `AddressFactory` issue
+
+
+## 1.1.3 - 2021-08-04
+- bump sfneal/mock-models min dev requirements to v0.9
+- refactor import of `ModelAttributeAssertions` to `AssertModelAttributes`

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
         "phpunit/phpunit": ">=9.5.4",
         "orchestra/testbench": ">=6.7.1",
         "scrutinizer/ocular": "^1.8",
-        "sfneal/mock-models": ">=0.5"
+        "sfneal/mock-models": ">=0.9"
     },
     "extra": {
         "laravel": {

--- a/tests/Feature/MigrationsTest.php
+++ b/tests/Feature/MigrationsTest.php
@@ -2,7 +2,7 @@
 
 namespace Sfneal\Users\Tests\Feature;
 
-use Sfneal\Testing\Utils\Traits\ModelAttributeAssertions;
+use Sfneal\Testing\Utils\Traits\AssertModelAttributes;
 use Sfneal\Users\Models\Role;
 use Sfneal\Users\Models\Team;
 use Sfneal\Users\Models\User;
@@ -11,7 +11,7 @@ use Sfneal\Users\Tests\TestCase;
 
 class MigrationsTest extends TestCase
 {
-    use ModelAttributeAssertions;
+    use AssertModelAttributes;
 
     /**
      * Indicates whether the default seeder should run before each test.


### PR DESCRIPTION
- bump sfneal/mock-models min dev requirements to v0.9
- refactor import of `ModelAttributeAssertions` to `AssertModelAttributes`