### PR TITLE
Fix sfneal/address min version to v1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -188,3 +188,7 @@ All notable changes to `users` will be documented in this file
 ## 1.1.3 - 2021-08-04
 - bump sfneal/mock-models min dev requirements to v0.9
 - refactor import of `ModelAttributeAssertions` to `AssertModelAttributes`
+
+
+# 1.1.4 - 2021-08-18
+- fix sfneal/address min version to v1.2 since broken v1.2.0 & v1.2.1 versions have been removed 

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php": ">=7.4",
-        "sfneal/address": "^1.2.2",
+        "sfneal/address": "^1.2",
         "sfneal/caching": ">=1.0",
         "sfneal/casts": ">=1.1",
         "sfneal/currency": "^2.0",


### PR DESCRIPTION
- fix sfneal/address min version to v1.2 since broken v1.2.0 & v1.2.1 versions have been removed