### PR TITLE
sfneal/caching v2.0 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -192,3 +192,8 @@ All notable changes to `users` will be documented in this file
 
 # 1.1.4 - 2021-08-18
 - fix sfneal/address min version to v1.2 since broken v1.2.0 & v1.2.1 versions have been removed 
+
+
+# 1.1.5 - 2021-08-31
+- add support for sfneal/caching v2.0
+- fix use of '#' cache key id suffix delimiter with ':'

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=7.4",
         "sfneal/address": "^1.2",
-        "sfneal/caching": ">=1.0",
+        "sfneal/caching": "^1.3|^2.0",
         "sfneal/casts": ">=1.1",
         "sfneal/currency": "^2.0",
         "sfneal/datum": ">=1.4.1",

--- a/src/Queries/UserNotificationSubscriptionQuery.php
+++ b/src/Queries/UserNotificationSubscriptionQuery.php
@@ -75,6 +75,6 @@ class UserNotificationSubscriptionQuery extends Query
      */
     public function cacheKey(): string
     {
-        return "user:notification:subscription#{$this->notification}";
+        return "user:notification:subscription:{$this->notification}";
     }
 }

--- a/src/Queries/UserRolesQuery.php
+++ b/src/Queries/UserRolesQuery.php
@@ -40,7 +40,7 @@ class UserRolesQuery extends Query
      */
     public function cacheKey(): string
     {
-        return Role::getTableName().':types#user';
+        return Role::getTableName().':types:user';
     }
 
     /**


### PR DESCRIPTION
- add support for sfneal/caching v2.0
- fix use of '#' cache key id suffix delimiter with ':'