### PR TITLE
Optimize related `Address` model accessors in `User` model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -197,3 +197,10 @@ All notable changes to `users` will be documented in this file
 # 1.1.5 - 2021-08-31
 - add support for sfneal/caching v2.0
 - fix use of '#' cache key id suffix delimiter with ':'
+
+
+# 1.2.0 - 2021-09-02
+- bump sfneal/address & sfneal/models to latest versions to support use of `Address` accessor traits
+- add use of `AddressAccessors` trait in `User` model for providing access to related `Address` model attributes
+- add `accessors_are_accessible()` test method to `UserTest` for testing attribute accessors
+- fix composer package constraints to be more explicit

--- a/composer.json
+++ b/composer.json
@@ -17,13 +17,13 @@
     ],
     "require": {
         "php": ">=7.4",
-        "sfneal/address": "^1.2.12",
+        "sfneal/address": "^1.2.13",
         "sfneal/caching": "^1.3|^2.0",
         "sfneal/casts": "^1.1",
         "sfneal/currency": "^2.0",
         "sfneal/datum": "^1.4.1",
         "sfneal/laravel-helpers": "^2.0",
-        "sfneal/models": "^2.1",
+        "sfneal/models": "^2.7",
         "sfneal/post-office": "^1.0",
         "sfneal/scopes": "^1.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php": ">=7.4",
-        "sfneal/address": "^1.2",
+        "sfneal/address": "^1.2.12",
         "sfneal/caching": "^1.3|^2.0",
         "sfneal/casts": "^1.1",
         "sfneal/currency": "^2.0",

--- a/composer.json
+++ b/composer.json
@@ -19,13 +19,13 @@
         "php": ">=7.4",
         "sfneal/address": "^1.2",
         "sfneal/caching": "^1.3|^2.0",
-        "sfneal/casts": ">=1.1",
+        "sfneal/casts": "^1.1",
         "sfneal/currency": "^2.0",
-        "sfneal/datum": ">=1.4.1",
-        "sfneal/laravel-helpers": ">=2.0",
+        "sfneal/datum": "^1.4.1",
+        "sfneal/laravel-helpers": "^2.0",
         "sfneal/models": "^2.1",
-        "sfneal/post-office": ">=1.0",
-        "sfneal/scopes": ">=1.0"
+        "sfneal/post-office": "^1.0",
+        "sfneal/scopes": "^1.0"
     },
     "require-dev": {
         "phpunit/phpunit": ">=9.5.4",

--- a/src/Models/User.php
+++ b/src/Models/User.php
@@ -10,6 +10,7 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\HasOne;
 use Illuminate\Database\Eloquent\Relations\MorphOne;
 use Sfneal\Address\Models\Address;
+use Sfneal\Address\Models\Traits\AddressAccessors;
 use Sfneal\Casts\NewlineCast;
 use Sfneal\Currency\Currency;
 use Sfneal\Helpers\Strings\StringHelpers;
@@ -23,6 +24,7 @@ use Vkovic\LaravelCustomCasts\HasCustomCasts;
 class User extends AuthModel
 {
     // todo: refactor status to use Status model?
+    use AddressAccessors;
     use HasCustomCasts;
     use HasFactory;
 
@@ -399,68 +401,6 @@ class User extends AuthModel
     public function getNameLinkAttribute()
     {
         return '<a href="'.route('user.show', ['user'=>$this->id]).'">'.$this->name.'</a>';
-    }
-
-    /**
-     * Get the 'city_state' attribute.
-     *
-     * @return string
-     */
-    public function getCityStateAttribute()
-    {
-        return $this->address->city_state ?? null;
-    }
-
-    // todo: add address accessor method to a sfneal/address trait
-
-    /**
-     * Retrieve the User's 'address1' attribute.
-     *
-     * @return mixed
-     */
-    public function getAddress1Attribute()
-    {
-        return $this->address->address_1 ?? null;
-    }
-
-    /**
-     * Retrieve the User's 'address2' attribute.
-     *
-     * @return mixed
-     */
-    public function getAddress2Attribute()
-    {
-        return $this->address->address_2 ?? null;
-    }
-
-    /**
-     * Retrieve the User's 'city' attribute.
-     *
-     * @return mixed
-     */
-    public function getCityAttribute()
-    {
-        return $this->address->city ?? null;
-    }
-
-    /**
-     * Retrieve the User's 'state' attribute.
-     *
-     * @return mixed
-     */
-    public function getStateAttribute()
-    {
-        return $this->address->state ?? null;
-    }
-
-    /**
-     * Retrieve the User's 'zip' attribute.
-     *
-     * @return mixed
-     */
-    public function getZipAttribute()
-    {
-        return $this->address->zip ?? null;
     }
 
     /**

--- a/src/Models/User.php
+++ b/src/Models/User.php
@@ -281,16 +281,6 @@ class User extends AuthModel
     }
 
     /**
-     * Get the 'city_state' attribute.
-     *
-     * @return string
-     */
-    public function getCityStateAttribute()
-    {
-        return $this->address->city_state ?? null;
-    }
-
-    /**
      * Mutate the 'middle_name' attribute.
      *
      * @param string|null $value
@@ -409,6 +399,16 @@ class User extends AuthModel
     public function getNameLinkAttribute()
     {
         return '<a href="'.route('user.show', ['user'=>$this->id]).'">'.$this->name.'</a>';
+    }
+
+    /**
+     * Get the 'city_state' attribute.
+     *
+     * @return string
+     */
+    public function getCityStateAttribute()
+    {
+        return $this->address->city_state ?? null;
     }
 
     // todo: add address accessor method to a sfneal/address trait

--- a/tests/Unit/UserTest.php
+++ b/tests/Unit/UserTest.php
@@ -140,7 +140,7 @@ class UserTest extends TestCase implements CrudModelTest, ModelBuilderTest, Mode
             'name_suffix' => false,
             'list_name' => false,
 
-//            'city_state' => false,
+            'city_state' => false,
             'address_1' => false,
             'address_2' => false,
             'city' => false,

--- a/tests/Unit/UserTest.php
+++ b/tests/Unit/UserTest.php
@@ -167,9 +167,7 @@ class UserTest extends TestCase implements CrudModelTest, ModelBuilderTest, Mode
                 $this->assertNotNull($user->{$method}($user->{$attribute}), "The $method '{$method}()' returned null.");
                 $this->assertIsString($user->{$method}($user->{$attribute}), "The $method '{$method}()' is not a string.");
                 $this->assertEquals($user->{$attribute}, $user->{$method}($user->{$attribute}), "The attribute '{$attribute}' & the method '{$method}()' returned different values");
-            }
-
-            else {
+            } else {
                 $this->assertNotNull($user->{$method}(), "The $method '{$method}()' returned null.");
                 $this->assertIsString($user->{$method}(), "The $method '{$method}()' is not a string.");
                 $this->assertEquals($user->{$attribute}, $user->{$method}(), "The attribute '{$attribute}' & the method '{$method}()' returned different values");

--- a/tests/Unit/UserTest.php
+++ b/tests/Unit/UserTest.php
@@ -124,4 +124,56 @@ class UserTest extends TestCase implements CrudModelTest, ModelBuilderTest, Mode
             $this->assertInstanceOf(UserNotification::class, $notification);
         });
     }
+
+    /** @test */
+    public function accessors_are_accessible()
+    {
+        // todo: add provider
+        $user_id = (new RandomModelAttributeQuery(User::class, 'id'))->execute();
+        $user = User::query()->find($user_id);
+
+        $attributes = [
+            'first_name' => true,
+            'last_name' => true,
+            'name' => false,
+            'name_full' => false,
+            'name_suffix' => false,
+            'list_name' => false,
+
+//            'city_state' => false,
+            'address_1' => false,
+            'address_2' => false,
+            'city' => false,
+            'state' => false,
+            'zip' => false,
+
+            'email_link' => false,
+            'phone_work_link' => false,
+            'phone_mobile_link' => false,
+        ];
+
+        foreach ($attributes as $attribute => $override) {
+            $parts = array_map(function (string $piece) {
+                return ucfirst($piece);
+            }, explode('_', $attribute));
+            array_unshift($parts, 'get');
+            array_push($parts, 'Attribute');
+            $method = implode('', $parts);
+
+            $this->assertNotNull($user->{$attribute}, "The attribute '{$attribute}' returned null.");
+            $this->assertIsString($user->{$attribute}, "The attribute '{$attribute}' is not a string.");
+
+            if ($override) {
+                $this->assertNotNull($user->{$method}($user->{$attribute}), "The $method '{$method}()' returned null.");
+                $this->assertIsString($user->{$method}($user->{$attribute}), "The $method '{$method}()' is not a string.");
+                $this->assertEquals($user->{$attribute}, $user->{$method}($user->{$attribute}), "The attribute '{$attribute}' & the method '{$method}()' returned different values");
+            }
+
+            else {
+                $this->assertNotNull($user->{$method}(), "The $method '{$method}()' returned null.");
+                $this->assertIsString($user->{$method}(), "The $method '{$method}()' is not a string.");
+                $this->assertEquals($user->{$attribute}, $user->{$method}(), "The attribute '{$attribute}' & the method '{$method}()' returned different values");
+            }
+        }
+    }
 }


### PR DESCRIPTION
- bump sfneal/address & sfneal/models to latest versions to support use of `Address` accessor traits
- add use of `AddressAccessors` trait in `User` model for providing access to related `Address` model attributes
- add `accessors_are_accessible()` test method to `UserTest` for testing attribute accessors
- fix composer package constraints to be more explicit