### PR TITLE
Add assertions to `UserListQueryTest` with Sqlite support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -210,3 +210,8 @@ All notable changes to `users` will be documented in this file
 - fix issues with use of `invalidateCache()` methods not properly clearing cache
 - add assertions methods `UserRolesQueryTest` to confirm cache was properly cleared
 - bump sfneal/caching min version to v2.1.2 to support latest implementations of cache invalidation
+
+
+# 1.3.1 - 2021-09-07
+- bump min sfneal/models packages version to v2.8.1
+- add assertions to `UserListQueryTest` now that issues with Sqlite concat & if statements has been resolved

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "sfneal/currency": "^2.0",
         "sfneal/datum": "^1.4.1",
         "sfneal/laravel-helpers": "^2.0",
-        "sfneal/models": "^2.7",
+        "sfneal/models": "^2.8.1",
         "sfneal/post-office": "^1.0",
         "sfneal/scopes": "^1.0"
     },

--- a/tests/Feature/Queries/UserListQueryTest.php
+++ b/tests/Feature/Queries/UserListQueryTest.php
@@ -48,8 +48,7 @@ class UserListQueryTest extends TestCase
         $this->assertIsInt($count);
         $this->assertEquals(1, $count);
 
-        foreach ($items as $item)
-        {
+        foreach ($items as $item) {
             $this->assertIsInt($item['id']);
             $this->assertIsString($item['text']);
 

--- a/tests/Feature/Queries/UserListQueryTest.php
+++ b/tests/Feature/Queries/UserListQueryTest.php
@@ -2,7 +2,6 @@
 
 namespace Sfneal\Users\Tests\Feature\Queries;
 
-use Illuminate\Database\QueryException;
 use Sfneal\Queries\RandomModelAttributeQuery;
 use Sfneal\Testing\Utils\Traits\CreateRequest;
 use Sfneal\Users\Models\User;
@@ -11,8 +10,6 @@ use Sfneal\Users\Tests\TestCase;
 
 class UserListQueryTest extends TestCase
 {
-    // todo: fix issue with sql 'concat' method not being available
-
     use CreateRequest;
 
     /**
@@ -39,12 +36,24 @@ class UserListQueryTest extends TestCase
         $request = $this->createRequest([], [
             'q' => $this->userName,
         ]);
-        try {
-            $result = (new UserListQuery($request))->execute();
-//            print_r($result);
-        } catch (QueryException $exception) {
-//            print_r('UserListQueryTest::query_returns_results - '.$exception->getMessage());
-            $this->assertTrue(true);
+
+        $result = (new UserListQuery($request))->execute();
+        $items = $result['items'];
+        $count = $result['total_count'];
+
+        $this->assertIsArray($result);
+        $this->assertIsArray($items);
+        $this->assertCount(1, $items);
+
+        $this->assertIsInt($count);
+        $this->assertEquals(1, $count);
+
+        foreach ($items as $item)
+        {
+            $this->assertIsInt($item['id']);
+            $this->assertIsString($item['text']);
+
+            $this->assertEquals($this->userName, $item['text']);
         }
     }
 }


### PR DESCRIPTION
- bump min sfneal/models packages version to v2.8.1
- add assertions to `UserListQueryTest` now that issues with Sqlite concat & if statements has been resolved