### PR TITLE
Refactor `UserListQuery` to accept a name query string parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -218,4 +218,4 @@ All notable changes to `users` will be documented in this file
 
 
 # 1.4.0 - 2021-09-07
-- refactor `UserListQuery` to accept a name query string as a parameter instead of a Request
+- refactor `UserListQuery` to accept a name query string as a parameter instead of a Request #43

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -215,3 +215,7 @@ All notable changes to `users` will be documented in this file
 # 1.3.1 - 2021-09-07
 - bump min sfneal/models packages version to v2.8.1
 - add assertions to `UserListQueryTest` now that issues with Sqlite concat & if statements has been resolved
+
+
+# 1.4.0 - 2021-09-07
+- refactor `UserListQuery` to accept a name query string as a parameter instead of a Request

--- a/src/Queries/UserListQuery.php
+++ b/src/Queries/UserListQuery.php
@@ -2,28 +2,25 @@
 
 namespace Sfneal\Users\Queries;
 
-use Illuminate\Http\Request;
 use Sfneal\Queries\Query;
 use Sfneal\Users\Builders\UserBuilder;
 use Sfneal\Users\Models\User;
 
 class UserListQuery extends Query
 {
-    // todo: refactor to use param instead of $request?
-
     /**
-     * @var Request
+     * @var string Query string containing portions of a User's name
      */
-    private $request;
+    private $nameQuery;
 
     /**
      * TeamListQuery constructor.
      *
-     * @param Request $request
+     * @param string $nameQuery
      */
-    public function __construct(Request $request)
+    public function __construct(string $nameQuery)
     {
-        $this->request = $request;
+        $this->nameQuery = $nameQuery;
     }
 
     /**
@@ -44,7 +41,7 @@ class UserListQuery extends Query
     public function execute(): array
     {
         return $this->builder()
-            ->whereNameLike($this->request->input('q'))
+            ->whereNameLike($this->nameQuery)
             ->whereActive()
             ->selectRawJson()
             ->countAndPaginate();

--- a/tests/Feature/Queries/UserListQueryTest.php
+++ b/tests/Feature/Queries/UserListQueryTest.php
@@ -3,15 +3,12 @@
 namespace Sfneal\Users\Tests\Feature\Queries;
 
 use Sfneal\Queries\RandomModelAttributeQuery;
-use Sfneal\Testing\Utils\Traits\CreateRequest;
 use Sfneal\Users\Models\User;
 use Sfneal\Users\Queries\UserListQuery;
 use Sfneal\Users\Tests\TestCase;
 
 class UserListQueryTest extends TestCase
 {
-    use CreateRequest;
-
     /**
      * @var string
      */

--- a/tests/Feature/Queries/UserListQueryTest.php
+++ b/tests/Feature/Queries/UserListQueryTest.php
@@ -33,11 +33,7 @@ class UserListQueryTest extends TestCase
     /** @test */
     public function query_returns_results()
     {
-        $request = $this->createRequest([], [
-            'q' => $this->userName,
-        ]);
-
-        $result = (new UserListQuery($request))->execute();
+        $result = (new UserListQuery($this->userName))->execute();
         $items = $result['items'];
         $count = $result['total_count'];
 


### PR DESCRIPTION
- refactor `UserListQuery` to accept a name query string as a parameter instead of a Request #43

resolves #43 