### PR TITLE
Add use of DataProviders in test suite & fix issue with wrapping names with apostrophes in queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -223,4 +223,4 @@ All notable changes to `users` will be documented in this file
  
 # 1.4.1 - 2021-09-08
 - fix issue with `UserBuilder::whereNameLikeRaw()` method causing errors when wrapping names with apostrophes (like "O'hare") #56
-- add use of `runTestFiveTimesProvider()` data provider for getting test methods that use random attributes to run multiple times #48
+- add use of `runTestFiveTimesProvider()` data provider for forcing test methods that use random attributes to run multiple times #48

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -219,3 +219,8 @@ All notable changes to `users` will be documented in this file
 
 # 1.4.0 - 2021-09-07
 - refactor `UserListQuery` to accept a name query string as a parameter instead of a Request #43
+
+ 
+# 1.4.1 - 2021-09-08
+- fix issue with `UserBuilder::whereNameLikeRaw()` method causing errors when wrapping names with apostrophes (like "O'hare") #56
+- add use of `runTestFiveTimesProvider()` data provider for getting test methods that use random attributes to run multiple times #48

--- a/src/Builders/Interfaces/WhereUserInterface.php
+++ b/src/Builders/Interfaces/WhereUserInterface.php
@@ -7,7 +7,7 @@ interface WhereUserInterface
     /**
      * Scope query results to particular users.
      *
-     * @param int $user_id
+     * @param  int  $user_id
      *
      * @return $this
      */
@@ -16,7 +16,7 @@ interface WhereUserInterface
     /**
      * Scope query to activity that was performed by any of the specified users.
      *
-     * @param array $user_ids
+     * @param  array  $user_ids
      *
      * @return $this
      */

--- a/src/Builders/RoleBuilder.php
+++ b/src/Builders/RoleBuilder.php
@@ -9,9 +9,9 @@ class RoleBuilder extends QueryBuilder
     /**
      * Scope Role query to roles of a particular type.
      *
-     * @param string $type
-     * @param string $operator
-     * @param string $boolean
+     * @param  string  $type
+     * @param  string  $operator
+     * @param  string  $boolean
      *
      * @return $this
      */
@@ -25,8 +25,8 @@ class RoleBuilder extends QueryBuilder
     /**
      * Scope Role query to only 'user' type roles.
      *
-     * @param string $operator
-     * @param string $boolean
+     * @param  string  $operator
+     * @param  string  $boolean
      *
      * @return $this
      */
@@ -40,9 +40,9 @@ class RoleBuilder extends QueryBuilder
     /**
      * Scope query results to Role's matching a role 'name'.
      *
-     * @param string $name
-     * @param string $operator
-     * @param string $boolean
+     * @param  string  $name
+     * @param  string  $operator
+     * @param  string  $boolean
      * @return $this
      */
     public function whereName(string $name, string $operator = '=', string $boolean = 'and'): self
@@ -55,8 +55,8 @@ class RoleBuilder extends QueryBuilder
     /**
      * Scope query results to Role's that do NOT have a particular role 'name'.
      *
-     * @param string $name
-     * @param string $boolean
+     * @param  string  $name
+     * @param  string  $boolean
      * @return $this
      */
     public function whereNameNot(string $name, string $boolean = 'and'): self
@@ -69,9 +69,9 @@ class RoleBuilder extends QueryBuilder
     /**
      * Scope query results to Role's with names that are in the array of $names.
      *
-     * @param array $names
-     * @param string $boolean
-     * @param bool $not
+     * @param  array  $names
+     * @param  string  $boolean
+     * @param  bool  $not
      * @return $this
      */
     public function whereNameIn(array $names, string $boolean = 'and', bool $not = false): self
@@ -84,8 +84,8 @@ class RoleBuilder extends QueryBuilder
     /**
      * Scope query results to Role's with names that are NOT in the array of $names.
      *
-     * @param array $names
-     * @param string $boolean
+     * @param  array  $names
+     * @param  string  $boolean
      * @return $this
      */
     public function whereNameNotIn(array $names, string $boolean = 'and'): self

--- a/src/Builders/Traits/WhereUser.php
+++ b/src/Builders/Traits/WhereUser.php
@@ -9,7 +9,7 @@ trait WhereUser
     /**
      * Scope query to activity that was performed by a particular user.
      *
-     * @param int $user_id
+     * @param  int  $user_id
      *
      * @return $this|WhereUserInterface
      */
@@ -23,7 +23,7 @@ trait WhereUser
     /**
      * Scope query to activity that was performed by any of the specified users.
      *
-     * @param array $user_ids
+     * @param  array  $user_ids
      *
      * @return $this|WhereUserInterface
      */

--- a/src/Builders/UserBuilder.php
+++ b/src/Builders/UserBuilder.php
@@ -150,7 +150,7 @@ class UserBuilder extends QueryBuilder implements WhereUserInterface
      *
      * @return $this
      */
-    public function whereActive($value = 1): self
+    public function whereActive(int $value = 1): self
     {
         $this->where('status', '=', $value);
 
@@ -344,7 +344,7 @@ class UserBuilder extends QueryBuilder implements WhereUserInterface
      *
      * @return Collection
      */
-    public function allWithInactive($columns = ['*']): Collection
+    public function allWithInactive(array $columns = ['*']): Collection
     {
         return $this->withInactive()->get($columns);
     }

--- a/src/Builders/UserBuilder.php
+++ b/src/Builders/UserBuilder.php
@@ -26,7 +26,7 @@ class UserBuilder extends QueryBuilder implements WhereUserInterface
     /**
      * UserBuilder constructor.
      *
-     * @param Builder $query
+     * @param  Builder  $query
      */
     public function __construct(Builder $query)
     {
@@ -37,9 +37,9 @@ class UserBuilder extends QueryBuilder implements WhereUserInterface
     /**
      * Find a User.
      *
-     * @param int $user_id
-     * @param string $operator
-     * @param string $boolean
+     * @param  int  $user_id
+     * @param  string  $operator
+     * @param  string  $boolean
      * @return $this
      */
     public function whereUser(int $user_id, string $operator = '=', string $boolean = 'and'): self
@@ -52,8 +52,8 @@ class UserBuilder extends QueryBuilder implements WhereUserInterface
     /**
      * Exclude a User.
      *
-     * @param int $user_id
-     * @param string $boolean
+     * @param  int  $user_id
+     * @param  string  $boolean
      * @return $this
      */
     public function whereUserNot(int $user_id, string $boolean = 'and'): self
@@ -66,9 +66,9 @@ class UserBuilder extends QueryBuilder implements WhereUserInterface
     /**
      * Scope query to User's that have an 'id' found in the array of $user_ids.
      *
-     * @param array $user_ids
-     * @param string $boolean
-     * @param bool $not
+     * @param  array  $user_ids
+     * @param  string  $boolean
+     * @param  bool  $not
      * @return $this|WhereUserInterface
      */
     public function whereUserIn(array $user_ids, string $boolean = 'and', bool $not = false): self
@@ -81,8 +81,8 @@ class UserBuilder extends QueryBuilder implements WhereUserInterface
     /**
      * Scope query to User's that does NOT have 'id' found in the array of $user_ids.
      *
-     * @param array $user_ids
-     * @param string $boolean
+     * @param  array  $user_ids
+     * @param  string  $boolean
      * @return $this|WhereUserInterface
      */
     public function whereUserNotIn(array $user_ids, string $boolean = 'and'): self
@@ -109,7 +109,7 @@ class UserBuilder extends QueryBuilder implements WhereUserInterface
     /**
      * Scope a query to User's with names starting with a particular string.
      *
-     * @param string $name
+     * @param  string  $name
      *
      * @return $this
      */
@@ -130,8 +130,8 @@ class UserBuilder extends QueryBuilder implements WhereUserInterface
     /**
      * Add a whereNameLike scope with custom columns (like concatenated).
      *
-     * @param string      $name
-     * @param string|null $column
+     * @param  string  $name
+     * @param  string|null  $column
      *
      * @return $this
      */
@@ -146,7 +146,7 @@ class UserBuilder extends QueryBuilder implements WhereUserInterface
     /**
      * Active Users.
      *
-     * @param int $value
+     * @param  int  $value
      *
      * @return $this
      */
@@ -160,9 +160,9 @@ class UserBuilder extends QueryBuilder implements WhereUserInterface
     /**
      * Scope query results to User's with a particular 'role_id'.
      *
-     * @param int $role_id
-     * @param string $operator
-     * @param string $boolean
+     * @param  int  $role_id
+     * @param  string  $operator
+     * @param  string  $boolean
      * @return $this
      */
     public function whereRole(int $role_id, string $operator = '=', string $boolean = 'and'): self
@@ -175,8 +175,8 @@ class UserBuilder extends QueryBuilder implements WhereUserInterface
     /**
      * Scope query results to User's without a particular 'role_id'.
      *
-     * @param int $role_id
-     * @param string $boolean
+     * @param  int  $role_id
+     * @param  string  $boolean
      * @return $this
      */
     public function whereRoleNot(int $role_id, string $boolean = 'and'): self
@@ -189,9 +189,9 @@ class UserBuilder extends QueryBuilder implements WhereUserInterface
     /**
      * Scope query results to User's with a 'role_id' found in the array of $role_ids.
      *
-     * @param array $role_ids
-     * @param string $boolean
-     * @param bool $not
+     * @param  array  $role_ids
+     * @param  string  $boolean
+     * @param  bool  $not
      * @return $this
      */
     public function whereRoleIn(array $role_ids, string $boolean = 'and', bool $not = false): self
@@ -204,8 +204,8 @@ class UserBuilder extends QueryBuilder implements WhereUserInterface
     /**
      * Scope query results to User's with a 'role_id' that is NOT found in the array of $role_ids.
      *
-     * @param array $role_ids
-     * @param string $boolean
+     * @param  array  $role_ids
+     * @param  string  $boolean
      * @return $this
      */
     public function whereRoleNotIn(array $role_ids, string $boolean = 'and'): self
@@ -218,8 +218,8 @@ class UserBuilder extends QueryBuilder implements WhereUserInterface
     /**
      * Add a `whereRole()` clause to query using the 'or' boolean.
      *
-     * @param int $role_id
-     * @param string $operator
+     * @param  int  $role_id
+     * @param  string  $operator
      * @return $this
      */
     public function orWhereRole(int $role_id, string $operator = '='): self
@@ -232,9 +232,9 @@ class UserBuilder extends QueryBuilder implements WhereUserInterface
     /**
      * Scope query results to User's with a particular role 'name'.
      *
-     * @param string $role_name
-     * @param string $operator
-     * @param int $count
+     * @param  string  $role_name
+     * @param  string  $operator
+     * @param  int  $count
      * @return $this
      */
     public function whereRoleName(string $role_name, string $operator = '>=', int $count = 1): self
@@ -249,9 +249,9 @@ class UserBuilder extends QueryBuilder implements WhereUserInterface
     /**
      * Scope query results to Role's that do NOT have a particular role 'name'.
      *
-     * @param string $role_name
-     * @param string $operator
-     * @param int $count
+     * @param  string  $role_name
+     * @param  string  $operator
+     * @param  int  $count
      * @return $this
      */
     public function whereRoleNameNot(string $role_name, string $operator = '>=', int $count = 1): self
@@ -266,9 +266,9 @@ class UserBuilder extends QueryBuilder implements WhereUserInterface
     /**
      * Scope query results to User's with role names that are in the array of $role_names.
      *
-     * @param array $role_names
-     * @param string $operator
-     * @param int $count
+     * @param  array  $role_names
+     * @param  string  $operator
+     * @param  int  $count
      * @return $this
      */
     public function whereRoleNameIn(array $role_names, string $operator = '>=', int $count = 1): self
@@ -283,9 +283,9 @@ class UserBuilder extends QueryBuilder implements WhereUserInterface
     /**
      * Scope query results to User's with role names that are NOT in the array of $role_names.
      *
-     * @param array $role_names
-     * @param string $operator
-     * @param int $count
+     * @param  array  $role_names
+     * @param  string  $operator
+     * @param  int  $count
      * @return $this
      */
     public function whereRoleNameNotIn(array $role_names, string $operator = '>=', int $count = 1): self
@@ -300,9 +300,9 @@ class UserBuilder extends QueryBuilder implements WhereUserInterface
     /**
      * Scope query results to User's that have roles.
      *
-     * @param Closure|null $callback
-     * @param string $operator
-     * @param int $count
+     * @param  Closure|null  $callback
+     * @param  string  $operator
+     * @param  int  $count
      * @return $this
      */
     public function whereHasRole(Closure $callback = null, $operator = '>=', $count = 1): self
@@ -340,7 +340,7 @@ class UserBuilder extends QueryBuilder implements WhereUserInterface
     /**
      * Retrieve all Users regardless of 'active status'.
      *
-     * @param array $columns
+     * @param  array  $columns
      *
      * @return Collection
      */

--- a/src/Builders/UserBuilder.php
+++ b/src/Builders/UserBuilder.php
@@ -138,7 +138,7 @@ class UserBuilder extends QueryBuilder implements WhereUserInterface
     private function whereNameLikeRaw(string $name, string $column = null): self
     {
         // Use concatName method if no $column was provided
-        $this->whereRaw(($column ?? $this->concatName())." LIKE '%{$name}%'");
+        $this->whereRaw(($column ?? $this->concatName()).' LIKE "%'.$name.'%"');
 
         return $this;
     }

--- a/src/Builders/UserNotificationBuilder.php
+++ b/src/Builders/UserNotificationBuilder.php
@@ -20,9 +20,9 @@ class UserNotificationBuilder extends QueryBuilder implements WhereUserInterface
     /**
      * Scope Query to UserNotification's of a certain 'type'.
      *
-     * @param string $type
-     * @param string $operator
-     * @param string $boolean
+     * @param  string  $type
+     * @param  string  $operator
+     * @param  string  $boolean
      *
      * @return $this
      */

--- a/src/Helpers/auth.php
+++ b/src/Helpers/auth.php
@@ -35,7 +35,7 @@ function activeUserName()
 /**
  * Check if the active user has a particular role or retrieve the active user's role name.
  *
- * @param string|int|null $role
+ * @param  string|int|null  $role
  *
  * @return string|bool|null
  */
@@ -60,7 +60,7 @@ function activeUserRole($role = null)
 /**
  * Determine if a User is an admin or is the active user.
  *
- * @param int $user_id
+ * @param  int  $user_id
  *
  * @return bool
  */
@@ -72,7 +72,7 @@ function isAdminOrActiveUser(int $user_id): bool
 /**
  * Determine if a $user_id is the active user.
  *
- * @param int $user_id
+ * @param  int  $user_id
  * @return bool
  */
 function isActiveUser(int $user_id): bool

--- a/src/Models/Role.php
+++ b/src/Models/Role.php
@@ -99,7 +99,7 @@ class Role extends Model
     /**
      * Retrieve the 'class' attribute with a default value.
      *
-     * @param null $value
+     * @param  null  $value
      *
      * @return string
      */

--- a/src/Models/User.php
+++ b/src/Models/User.php
@@ -175,7 +175,7 @@ class User extends AuthModel
     /**
      * Determine if a User has a particular 'role_id'.
      *
-     * @param int $role_id
+     * @param  int  $role_id
      * @return bool
      */
     public function isRoleId(int $role_id): bool
@@ -186,7 +186,7 @@ class User extends AuthModel
     /**
      * Determine if a User has a particular 'role name'.
      *
-     * @param string $role
+     * @param  string  $role
      * @return bool
      */
     public function isRole(string $role): bool
@@ -274,7 +274,7 @@ class User extends AuthModel
     /**
      * Get the AWS S3 file upload directory for an Inquiry model by retrieving the table name and primary key.
      *
-     * @param string $base_dir
+     * @param  string  $base_dir
      * @return string
      */
     public function getUploadDirectory($base_dir = 'images'): string
@@ -285,7 +285,7 @@ class User extends AuthModel
     /**
      * Mutate the 'middle_name' attribute.
      *
-     * @param string|null $value
+     * @param  string|null  $value
      */
     public function setMiddleNameAttribute(string $value = null)
     {
@@ -301,7 +301,7 @@ class User extends AuthModel
     /**
      * Mutate the 'first_name' attribute.
      *
-     * @param string|null $value
+     * @param  string|null  $value
      */
     public function setFirstNameAttribute(string $value = null)
     {
@@ -313,7 +313,7 @@ class User extends AuthModel
     /**
      * Mutate the 'last_name' attribute.
      *
-     * @param string|null $value
+     * @param  string|null  $value
      */
     public function setLastNameAttribute(string $value = null)
     {
@@ -325,7 +325,7 @@ class User extends AuthModel
     /**
      * Access the 'first_name' attribute.
      *
-     * @param string|null $value
+     * @param  string|null  $value
      * @return string
      */
     public function getFirstNameAttribute(string $value = null): string
@@ -336,7 +336,7 @@ class User extends AuthModel
     /**
      * Access the 'last_name' attribute.
      *
-     * @param string|null $value
+     * @param  string|null  $value
      * @return string
      */
     public function getLastNameAttribute(string $value = null): string

--- a/src/Queries/UserListQuery.php
+++ b/src/Queries/UserListQuery.php
@@ -16,7 +16,7 @@ class UserListQuery extends Query
     /**
      * TeamListQuery constructor.
      *
-     * @param string $nameQuery
+     * @param  string  $nameQuery
      */
     public function __construct(string $nameQuery)
     {

--- a/src/Queries/UserNotificationSubscriptionQuery.php
+++ b/src/Queries/UserNotificationSubscriptionQuery.php
@@ -24,7 +24,7 @@ class UserNotificationSubscriptionQuery extends Query
     /**
      * UserNotificationSubscriptionQuery constructor.
      *
-     * @param Notification $notification
+     * @param  Notification  $notification
      */
     public function __construct(Notification $notification)
     {

--- a/src/Scopes/UserActiveScope.php
+++ b/src/Scopes/UserActiveScope.php
@@ -12,8 +12,8 @@ class UserActiveScope implements Scope
     /**
      * Order results by creation time (newest to oldest).
      *
-     * @param Builder|UserBuilder $builder
-     * @param EloquentModel       $model
+     * @param  Builder|UserBuilder  $builder
+     * @param  EloquentModel  $model
      *
      * @return void
      */

--- a/src/Services/OrganizationService.php
+++ b/src/Services/OrganizationService.php
@@ -37,7 +37,7 @@ class OrganizationService
     /**
      * Retrieve the Organization's phone number.
      *
-     * @param bool $href
+     * @param  bool  $href
      * @return string|null
      */
     public static function phone(bool $href = false): ?string
@@ -54,7 +54,7 @@ class OrganizationService
     /**
      * Retrieve the Organization's email address.
      *
-     * @param bool $href
+     * @param  bool  $href
      * @return string|null
      */
     public static function email(bool $href = false): ?string

--- a/tests/Feature/Builders/BuilderTestCase.php
+++ b/tests/Feature/Builders/BuilderTestCase.php
@@ -5,7 +5,7 @@ namespace Sfneal\Users\Tests\Feature\Builders;
 use Sfneal\Models\Model;
 use Sfneal\Users\Tests\TestCase;
 
-class BuilderTestCase extends TestCase
+abstract class BuilderTestCase extends TestCase
 {
     /**
      * @var Model

--- a/tests/Feature/Builders/RoleBuilderTest.php
+++ b/tests/Feature/Builders/RoleBuilderTest.php
@@ -12,7 +12,10 @@ class RoleBuilderTest extends BuilderTestCase
      */
     protected $modelClass = Role::class;
 
-    /** @test */
+    /**
+     * @test
+     * @dataProvider runTestFiveTimesProvider
+     */
     public function whereType()
     {
         $attribute = 'type';
@@ -32,7 +35,10 @@ class RoleBuilderTest extends BuilderTestCase
         $this->assertContains($value, $model->pluck($attribute));
     }
 
-    /** @test */
+    /**
+     * @test
+     * @dataProvider runTestFiveTimesProvider
+     */
     public function whereName()
     {
         $attribute = 'name';
@@ -42,7 +48,10 @@ class RoleBuilderTest extends BuilderTestCase
         $this->assertContains($value, $model->pluck($attribute));
     }
 
-    /** @test */
+    /**
+     * @test
+     * @dataProvider runTestFiveTimesProvider
+     */
     public function whereNameNot()
     {
         $attribute = 'name';
@@ -52,7 +61,10 @@ class RoleBuilderTest extends BuilderTestCase
         $this->assertNotContains($value, $model->pluck($attribute));
     }
 
-    /** @test */
+    /**
+     * @test
+     * @dataProvider runTestFiveTimesProvider
+     */
     public function whereNameIn()
     {
         $attribute = 'name';
@@ -64,7 +76,10 @@ class RoleBuilderTest extends BuilderTestCase
         });
     }
 
-    /** @test */
+    /**
+     * @test
+     * @dataProvider runTestFiveTimesProvider
+     */
     public function whereNameNotIn()
     {
         $attribute = 'name';

--- a/tests/Feature/Builders/UserBuilderTest.php
+++ b/tests/Feature/Builders/UserBuilderTest.php
@@ -18,7 +18,10 @@ class UserBuilderTest extends BuilderTestCase
      */
     protected $modelClass = User::class;
 
-    /** @test */
+    /**
+     * @test
+     * @dataProvider runTestFiveTimesProvider
+     */
     public function whereUser()
     {
         $attribute = 'id';
@@ -28,7 +31,10 @@ class UserBuilderTest extends BuilderTestCase
         $this->assertContains($value, $model->pluck($attribute));
     }
 
-    /** @test */
+    /**
+     * @test
+     * @dataProvider runTestFiveTimesProvider
+     */
     public function whereUserNot()
     {
         $attribute = 'id';
@@ -38,7 +44,10 @@ class UserBuilderTest extends BuilderTestCase
         $this->assertNotContains($value, $model->pluck($attribute));
     }
 
-    /** @test */
+    /**
+     * @test
+     * @dataProvider runTestFiveTimesProvider
+     */
     public function whereUserIn()
     {
         $attribute = 'id';
@@ -50,7 +59,10 @@ class UserBuilderTest extends BuilderTestCase
         });
     }
 
-    /** @test */
+    /**
+     * @test
+     * @dataProvider runTestFiveTimesProvider
+     */
     public function whereUserNotIn()
     {
         $attribute = 'id';
@@ -62,7 +74,10 @@ class UserBuilderTest extends BuilderTestCase
         });
     }
 
-    /** @test */
+    /**
+     * @test
+     * @dataProvider runTestFiveTimesProvider
+     */
     public function whereUsername()
     {
         $attribute = 'username';
@@ -72,7 +87,10 @@ class UserBuilderTest extends BuilderTestCase
         $this->assertContains($value, $model->pluck($attribute));
     }
 
-    /** @test */
+    /**
+     * @test
+     * @dataProvider runTestFiveTimesProvider
+     */
     public function whereRole()
     {
         $attribute = 'role_id';
@@ -82,7 +100,10 @@ class UserBuilderTest extends BuilderTestCase
         $this->assertContains($value, $model->pluck($attribute));
     }
 
-    /** @test */
+    /**
+     * @test
+     * @dataProvider runTestFiveTimesProvider
+     */
     public function whereRoleNot()
     {
         $attribute = 'role_id';
@@ -92,7 +113,10 @@ class UserBuilderTest extends BuilderTestCase
         $this->assertNotContains($value, $model->pluck($attribute));
     }
 
-    /** @test */
+    /**
+     * @test
+     * @dataProvider runTestFiveTimesProvider
+     */
     public function whereRoleIn()
     {
         $attribute = 'role_id';
@@ -104,7 +128,10 @@ class UserBuilderTest extends BuilderTestCase
         });
     }
 
-    /** @test */
+    /**
+     * @test
+     * @dataProvider runTestFiveTimesProvider
+     */
     public function whereRoleNotIn()
     {
         $attribute = 'role_id';
@@ -116,7 +143,10 @@ class UserBuilderTest extends BuilderTestCase
         });
     }
 
-    /** @test */
+    /**
+     * @test
+     * @dataProvider runTestFiveTimesProvider
+     */
     public function orWhereRole()
     {
         $attribute = 'role_id';
@@ -132,7 +162,10 @@ class UserBuilderTest extends BuilderTestCase
         });
     }
 
-    /** @test */
+    /**
+     * @test
+     * @dataProvider runTestFiveTimesProvider
+     */
     public function whereRoleName()
     {
         $attribute = 'name';
@@ -148,7 +181,10 @@ class UserBuilderTest extends BuilderTestCase
         });
     }
 
-    /** @test */
+    /**
+     * @test
+     * @dataProvider runTestFiveTimesProvider
+     */
     public function whereRoleNameNot()
     {
         $attribute = 'name';
@@ -164,7 +200,10 @@ class UserBuilderTest extends BuilderTestCase
         });
     }
 
-    /** @test */
+    /**
+     * @test
+     * @dataProvider runTestFiveTimesProvider
+     */
     public function whereRoleNameIn()
     {
         $attribute = 'name';
@@ -180,7 +219,10 @@ class UserBuilderTest extends BuilderTestCase
         });
     }
 
-    /** @test */
+    /**
+     * @test
+     * @dataProvider runTestFiveTimesProvider
+     */
     public function whereRoleNameNotIn()
     {
         $attribute = 'name';

--- a/tests/Feature/Builders/UserNotificationBuilderTest.php
+++ b/tests/Feature/Builders/UserNotificationBuilderTest.php
@@ -12,7 +12,10 @@ class UserNotificationBuilderTest extends BuilderTestCase
      */
     protected $modelClass = UserNotification::class;
 
-    /** @test */
+    /**
+     * @test
+     * @dataProvider runTestFiveTimesProvider
+     */
     public function whereType()
     {
         $attribute = 'type';

--- a/tests/Feature/Factories/FactoriesTestCase.php
+++ b/tests/Feature/Factories/FactoriesTestCase.php
@@ -6,7 +6,7 @@ use Sfneal\Models\Model;
 use Sfneal\Queries\RandomModelAttributeQuery;
 use Sfneal\Users\Tests\TestCase;
 
-class FactoriesTestCase extends TestCase
+abstract class FactoriesTestCase extends TestCase
 {
     // todo: add `ModelRelationshipsTest` implementations
 

--- a/tests/Feature/Factories/RoleFactoryTest.php
+++ b/tests/Feature/Factories/RoleFactoryTest.php
@@ -13,7 +13,10 @@ class RoleFactoryTest extends FactoriesTestCase implements FillablesTest
      */
     public $modelClass = Role::class;
 
-    /** @test */
+    /**
+     * @test
+     * @dataProvider runTestFiveTimesProvider
+     */
     public function fillables_are_correct_types()
     {
         $this->assertIsString($this->model->type);

--- a/tests/Feature/Factories/TeamFactoryTest.php
+++ b/tests/Feature/Factories/TeamFactoryTest.php
@@ -12,7 +12,10 @@ class TeamFactoryTest extends FactoriesTestCase implements FillablesTest
      */
     public $modelClass = Team::class;
 
-    /** @test */
+    /**
+     * @test
+     * @dataProvider runTestFiveTimesProvider
+     */
     public function fillables_are_correct_types()
     {
         $this->assertIsInt($this->model->user_id);

--- a/tests/Feature/Factories/UserFactoryTest.php
+++ b/tests/Feature/Factories/UserFactoryTest.php
@@ -13,7 +13,10 @@ class UserFactoryTest extends FactoriesTestCase implements FillablesTest
      */
     public $modelClass = User::class;
 
-    /** @test */
+    /**
+     * @test
+     * @dataProvider runTestFiveTimesProvider
+     */
     public function fillables_are_correct_types()
     {
         $this->assertIsInt($this->model->role_id);

--- a/tests/Feature/Factories/UserNotificationFactoryTest.php
+++ b/tests/Feature/Factories/UserNotificationFactoryTest.php
@@ -14,7 +14,10 @@ class UserNotificationFactoryTest extends FactoriesTestCase implements Fillables
      */
     public $modelClass = UserNotification::class;
 
-    /** @test */
+    /**
+     * @test
+     * @dataProvider runTestFiveTimesProvider
+     */
     public function fillables_are_correct_types()
     {
         $this->assertIsInt($this->model->user_id);

--- a/tests/Feature/Queries/UserListQueryTest.php
+++ b/tests/Feature/Queries/UserListQueryTest.php
@@ -27,7 +27,10 @@ class UserListQueryTest extends TestCase
         )->name;
     }
 
-    /** @test */
+    /**
+     * @test
+     * @dataProvider runTestFiveTimesProvider
+     */
     public function query_returns_results()
     {
         $result = (new UserListQuery($this->userName))->execute();

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -25,7 +25,7 @@ class TestCase extends OrchestraTestCase
     /**
      * Register package service providers.
      *
-     * @param Application $app
+     * @param  Application  $app
      * @return array|string
      */
     protected function getPackageProviders($app)
@@ -41,7 +41,7 @@ class TestCase extends OrchestraTestCase
     /**
      * Define environment setup.
      *
-     * @param Application $app
+     * @param  Application  $app
      * @return void
      */
     protected function getEnvironmentSetUp($app)

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -88,4 +88,22 @@ class TestCase extends OrchestraTestCase
         include_once __DIR__.'/../vendor/sfneal/address/database/migrations/create_address_table.php.stub';
         (new \CreateAddressTable())->up();
     }
+
+    /**
+     * A data provider that doesn't return parameters but forces a test method to be run five times.
+     *
+     *  - useful when a dataProvider requires a query for a random attribute
+     *
+     * @return array[]
+     */
+    public function runTestFiveTimesProvider(): array
+    {
+        return [
+            [],
+            [],
+            [],
+            [],
+            [],
+        ];
+    }
 }

--- a/tests/Unit/HelpersTest.php
+++ b/tests/Unit/HelpersTest.php
@@ -34,7 +34,10 @@ class HelpersTest extends TestCase
         $this->actingAs($this->user);
     }
 
-    /** @test */
+    /**
+     * @test
+     * @dataProvider runTestFiveTimesProvider
+     */
     public function activeUser()
     {
         $user = activeUser();
@@ -44,7 +47,10 @@ class HelpersTest extends TestCase
         $this->assertEquals($this->user, $user);
     }
 
-    /** @test */
+    /**
+     * @test
+     * @dataProvider runTestFiveTimesProvider
+     */
     public function activeUserID()
     {
         $user_id = activeUserID();
@@ -53,7 +59,10 @@ class HelpersTest extends TestCase
         $this->assertEquals($this->user->getKey(), $user_id);
     }
 
-    /** @test */
+    /**
+     * @test
+     * @dataProvider runTestFiveTimesProvider
+     */
     public function activeUserName()
     {
         $user_name = activeUserName();
@@ -62,7 +71,10 @@ class HelpersTest extends TestCase
         $this->assertEquals($this->user->name, $user_name);
     }
 
-    /** @test */
+    /**
+     * @test
+     * @dataProvider runTestFiveTimesProvider
+     */
     public function activeUserRole()
     {
         $role = activeUserRole();
@@ -72,7 +84,10 @@ class HelpersTest extends TestCase
         // todo: add test with $role param
     }
 
-    /** @test */
+    /**
+     * @test
+     * @dataProvider runTestFiveTimesProvider
+     */
     public function isAdminOrActiveUser()
     {
         // Active User
@@ -101,7 +116,10 @@ class HelpersTest extends TestCase
         $this->assertFalse($notActiveUser);
     }
 
-    /** @test */
+    /**
+     * @test
+     * @dataProvider runTestFiveTimesProvider
+     */
     public function isActiveUser()
     {
         $activeUser = isActiveUser(activeUserID());

--- a/tests/Unit/RoleTest.php
+++ b/tests/Unit/RoleTest.php
@@ -31,7 +31,10 @@ class RoleTest extends TestCase implements CrudModelTest, ModelBuilderTest, Mode
         });
     }
 
-    /** @test */
+    /**
+     * @test
+     * @dataProvider runTestFiveTimesProvider
+     */
     public function records_can_be_updated()
     {
         // Find a random Role
@@ -58,7 +61,10 @@ class RoleTest extends TestCase implements CrudModelTest, ModelBuilderTest, Mode
         $this->assertSame($desc, $updatedRole->description);
     }
 
-    /** @test */
+    /**
+     * @test
+     * @dataProvider runTestFiveTimesProvider
+     */
     public function records_can_be_deleted()
     {
         // Find a random Role
@@ -90,7 +96,10 @@ class RoleTest extends TestCase implements CrudModelTest, ModelBuilderTest, Mode
         $this->assertInstanceOf(RoleFactory::class, $factory);
     }
 
-    /** @test */
+    /**
+     * @test
+     * @dataProvider runTestFiveTimesProvider
+     */
     public function relationships_are_accessible()
     {
         $role_id = (new RandomModelAttributeQuery(Role::class, 'role_id'))->execute();


### PR DESCRIPTION
- fix issue with `UserBuilder::whereNameLikeRaw()` method causing errors when wrapping names with apostrophes (like "O'hare") #56
- add use of `runTestFiveTimesProvider()` data provider for getting test methods that use random attributes to run multiple times #48

fixes #56 
resolves #48 