### PR TITLE
sfneal/models, sfneal/address & test suite dependency upgrade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -248,3 +248,9 @@ All notable changes to `users` will be documented in this file
 
 # 2.0.3 - 2024-04-30
 - bump sfneal/caching requirement from ^2.1.2|^3.0 to ^2.1.2|^3.0|^4.0
+
+
+# 2.0.4 - 2024-05-06
+- bump sfneal dependencies to the latest versions
+- cut scrutinizer/ocular from composer requirements
+- fix test suite dependencies to prevent raising errors

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,6 @@
         "josiasmontag/laravel-redis-mock": ">=1.2.6",
         "orchestra/testbench": "^7.40|^8.0|9.0",
         "phpunit/phpunit": "^9.6|^10.0|^11.0",
-        "scrutinizer/ocular": "^1.8",
         "sfneal/mock-models": "^0.9 || ^0.11 || ^0.12"
     },
     "extra": {

--- a/composer.json
+++ b/composer.json
@@ -17,13 +17,13 @@
     ],
     "require": {
         "php": "^8.0|^8.1|^8.2|^8.3",
-        "sfneal/address": "^1.2.13 || ^2.0.0",
+        "sfneal/address": "^1.2.13 || ^2.0 || ^3.0",
         "sfneal/caching": "^2.1.2|^3.0|^4.0",
         "sfneal/casts": "^1.1|^2.0",
         "sfneal/currency": "^2.0",
         "sfneal/datum": "^1.4.1|^2.0",
         "sfneal/laravel-helpers": "^2.0",
-        "sfneal/models": "^2.8.1|^3.0.1",
+        "sfneal/models": "^2.8.1|^3.0|^4.0",
         "sfneal/scopes": "^1.0 || ^2.0"
     },
     "require-dev": {
@@ -31,7 +31,7 @@
         "orchestra/testbench": "^7.40|^8.0|9.0",
         "phpunit/phpunit": "^9.6|^10.0|^11.0",
         "scrutinizer/ocular": "^1.8",
-        "sfneal/mock-models": "^0.9 || ^0.11.0"
+        "sfneal/mock-models": "^0.9 || ^0.11 || ^0.12"
     },
     "extra": {
         "laravel": {

--- a/composer.json
+++ b/composer.json
@@ -28,8 +28,8 @@
     },
     "require-dev": {
         "josiasmontag/laravel-redis-mock": ">=1.2.6",
-        "orchestra/testbench": "^7.40|^8.0|9.0",
-        "phpunit/phpunit": "^9.6|^10.0|^11.0",
+        "orchestra/testbench": "^7.40|^8.0",
+        "phpunit/phpunit": "^9.6|^10.0",
         "sfneal/mock-models": "^0.9 || ^0.11 || ^0.12"
     },
     "extra": {


### PR DESCRIPTION
- bump sfneal dependencies to the latest versions
- cut scrutinizer/ocular from composer requirements
- fix test suite dependencies to prevent raising errors